### PR TITLE
Added a WYSIWYG Type menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Medium Upload
 
-Write your Medium stories in Atom like a hacker and upload them to directly Medium as a draft or a public story.
+Write your Medium stories in Atom - like a hacker - and upload them to directly Medium as a draft or a public story.
 
 ![info-bar](https://raw.githubusercontent.com/ericadamski/atom-medium-upload/master/assets/info-bar.png)
 

--- a/lib/components/main.jsx
+++ b/lib/components/main.jsx
@@ -1,30 +1,28 @@
-'use babel';
+"use babel";
 
-import React, { Component } from 'react';
-import styled from 'styled-components';
+import React, { Component } from "react";
+import styled from "styled-components";
 
-import User from './user.jsx';
-import Status from './status.jsx';
-import Menu from './menu.jsx';
+import User from "./user.jsx";
+import Status from "./status.jsx";
+import Menu from "./menu.jsx";
 
 const Container = styled.div`
-    max-height: 10rem;
-    padding: 0.5rem;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
+  max-height: 10rem;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 `;
 
 const StatusContainer = styled.div``;
 
-export default class Main extends Component {
-    render() {
-        return (
-            <Container>
-                <Status />
-                <User />
-                <Menu />
-            </Container>
-        );
-    }
-}
+const Main = () => (
+  <Container>
+    <Status />
+    <User />
+    <Menu />
+  </Container>
+);
+
+export default Main;

--- a/lib/components/main.jsx
+++ b/lib/components/main.jsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 
 import User from './user.jsx';
 import Status from './status.jsx';
+import Menu from './menu.jsx';
 
 const Container = styled.div`
     max-height: 10rem;
@@ -22,6 +23,7 @@ export default class Main extends Component {
             <Container>
                 <Status />
                 <User />
+                <Menu />
             </Container>
         );
     }

--- a/lib/components/menu.jsx
+++ b/lib/components/menu.jsx
@@ -1,0 +1,162 @@
+'use babel';
+
+import React, { Component } from 'react';
+import styled, { css } from 'styled-components';
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+import 'rxjs/add/observable/fromEvent';
+import 'rxjs/add/observable/fromPromise';
+import 'rxjs/add/operator/withLatestFrom';
+import 'rxjs/add/operator/filter';
+import 'rxjs/add/operator/partition';
+import path from 'path';
+
+import header from '../editor/header';
+import italic from '../editor/italic';
+import quote from '../editor/quote';
+import bold from '../editor/bold';
+import link from '../editor/link';
+
+const position = position => css`
+    position: fixed;
+    top: ${position.top}px;
+    left: ${position.left}px;
+`;
+
+const hide = css`
+    visibility: hidden;
+`;
+
+const Container = styled.div`
+    ${props => position(props.position)};
+    ${props => props.hidden && hide};
+    border-radius: 0.5em;
+    height: 3em;
+    background: black;
+    z-index: 100;
+    display: flex;
+    overflow: hidden;
+`;
+
+const EditorButton = styled.button`
+    background: transparent;
+    border: none;
+    margin: 0;
+    padding: 0 0.5em;
+    height: 100%;
+    width: 2.5em;
+
+    &:hover {
+        background: rgba(255, 255, 255, 0.4);
+    }
+`;
+
+export default class Menu extends Component {
+    state = { hidden: true, line: -1, position: { top: 0, left: 0 } };
+
+    editor = atom.workspace.getActiveTextEditor();
+
+    updateLine(fn) {
+        return () => {
+            this.editor.setTextInBufferRange(
+                this.editor.getBuffer().rangeForRow(this.state.line),
+                fn(this.editor.lineTextForBufferRow(this.state.line))
+            );
+
+            this.editor.setSelectedBufferRange(
+                this.editor.getBuffer().rangeForRow(this.state.line)
+            );
+
+            this.setState({
+                range: this.editor.getSelectedBufferRange(),
+            });
+        };
+    }
+
+    updateRange(fn) {
+        return () => {
+            this.editor.setTextInBufferRange(
+                this.state.range,
+                fn(this.editor.getTextInBufferRange(this.state.range))
+            );
+
+            this.setState({
+                range: this.editor.getSelectedBufferRange(),
+            });
+        };
+    }
+
+    initializeEvents(editor) {
+        if (path.basename(editor.getTitle(), '.md') === editor.getTitle())
+            return this.setState({ hidden: true });
+
+        this.subscriber && this.subscriber.unsubscribe();
+
+        const element = atom.views.getView(editor);
+
+        const selection$ = new Subject();
+
+        editor.onDidChangeSelectionRange(selection$.next.bind(selection$));
+
+        const [menu$, click$] = Observable.fromEvent(element, 'mouseup')
+            .withLatestFrom(
+                selection$,
+                ({ clientX, clientY }, { newBufferRange }) => ({
+                    range: newBufferRange,
+                    left: clientX,
+                    top: clientY,
+                })
+            )
+            .partition(({ range }) => !range.end.isEqual(range.start));
+
+        this.subscriber = Observable.fromEvent(element, 'mousewheel')
+            .merge(Observable.fromEvent(element, 'keydown'))
+            .merge(click$)
+            .filter(() => !this.state.hidden)
+            .subscribe(() => this.setState({ hidden: true }))
+            .add(
+                menu$
+                    .map(({ range, left, top }) => ({
+                        position: { left: left + 10, top: top + 10 },
+                        line: editor.getCursorBufferPosition().row,
+                        hidden: false,
+                        range,
+                    }))
+                    .subscribe(options => this.setState(options))
+            );
+
+        this.editor = editor;
+    }
+
+    componentDidMount() {
+        atom.workspace.onDidChangeActiveTextEditor(
+            this.initializeEvents.bind(this)
+        );
+
+        if (this.editor) this.initializeEvents(this.editor);
+    }
+
+    render() {
+        return (
+            <Container
+                hidden={this.state.hidden}
+                position={this.state.position}
+            >
+                <EditorButton onClick={this.updateLine(header(1))}>
+                    H1
+                </EditorButton>
+                <EditorButton onClick={this.updateLine(header(2))}>
+                    H2
+                </EditorButton>
+                <EditorButton onClick={this.updateLine(quote)}>"</EditorButton>
+                <EditorButton onClick={this.updateRange(bold)}>B</EditorButton>
+                <EditorButton onClick={this.updateRange(italic)}>
+                    I
+                </EditorButton>
+                <EditorButton onClick={this.updateRange(link)}>
+                    Link
+                </EditorButton>
+            </Container>
+        );
+    }
+}

--- a/lib/components/menu.jsx
+++ b/lib/components/menu.jsx
@@ -1,162 +1,154 @@
-'use babel';
+"use babel";
 
-import React, { Component } from 'react';
-import styled, { css } from 'styled-components';
-import { Observable } from 'rxjs/Observable';
-import { Subject } from 'rxjs/Subject';
-import 'rxjs/add/observable/fromEvent';
-import 'rxjs/add/observable/fromPromise';
-import 'rxjs/add/operator/withLatestFrom';
-import 'rxjs/add/operator/filter';
-import 'rxjs/add/operator/partition';
-import path from 'path';
+import React, { Component } from "react";
+import styled, { css } from "styled-components";
 
-import header from '../editor/header';
-import italic from '../editor/italic';
-import quote from '../editor/quote';
-import bold from '../editor/bold';
-import link from '../editor/link';
+import { MarkdownMenu } from "react-markdown-menu";
+
+import { Observable } from "rxjs/Observable";
+import { Subject } from "rxjs/Subject";
+import "rxjs/add/observable/fromEvent";
+import "rxjs/add/observable/fromPromise";
+import "rxjs/add/operator/withLatestFrom";
+import "rxjs/add/operator/filter";
+import "rxjs/add/operator/partition";
+import path from "path";
+
+import header from "../editor/header";
+import italic from "../editor/italic";
+import quote from "../editor/quote";
+import bold from "../editor/bold";
+import link from "../editor/link";
 
 const position = position => css`
-    position: fixed;
-    top: ${position.top}px;
-    left: ${position.left}px;
+  position: fixed;
+  top: ${position.top}px;
+  left: ${position.left}px;
 `;
 
 const hide = css`
-    visibility: hidden;
+  visibility: hidden;
 `;
 
 const Container = styled.div`
-    ${props => position(props.position)};
-    ${props => props.hidden && hide};
-    border-radius: 0.5em;
-    height: 3em;
-    background: black;
-    z-index: 100;
-    display: flex;
-    overflow: hidden;
+  ${props => position(props.position)};
+  ${props => props.hidden && hide};
+  border-radius: 0.5em;
+  height: 3em;
+  background: black;
+  z-index: 100;
+  display: flex;
+  overflow: hidden;
 `;
 
 const EditorButton = styled.button`
-    background: transparent;
-    border: none;
-    margin: 0;
-    padding: 0 0.5em;
-    height: 100%;
-    width: 2.5em;
+  background: transparent;
+  border: none;
+  margin: 0;
+  padding: 0 0.5em;
+  height: 100%;
+  width: 2.5em;
 
-    &:hover {
-        background: rgba(255, 255, 255, 0.4);
-    }
+  &:hover {
+    background: rgba(255, 255, 255, 0.4);
+  }
 `;
 
 export default class Menu extends Component {
-    state = { hidden: true, line: -1, position: { top: 0, left: 0 } };
+  state = { hidden: true, line: -1, position: { top: 0, left: 0 } };
 
-    editor = atom.workspace.getActiveTextEditor();
+  editor = atom.workspace.getActiveTextEditor();
 
-    updateLine(fn) {
-        return () => {
-            this.editor.setTextInBufferRange(
-                this.editor.getBuffer().rangeForRow(this.state.line),
-                fn(this.editor.lineTextForBufferRow(this.state.line))
-            );
+  updateLine(text) {
+    this.editor.setTextInBufferRange(
+      this.editor.getBuffer().rangeForRow(this.state.line),
+      text
+    );
 
-            this.editor.setSelectedBufferRange(
-                this.editor.getBuffer().rangeForRow(this.state.line)
-            );
+    this.editor.setSelectedBufferRange(
+      this.editor.getBuffer().rangeForRow(this.state.line)
+    );
 
-            this.setState({
-                range: this.editor.getSelectedBufferRange(),
-            });
-        };
-    }
+    this.setState({
+      range: this.editor.getSelectedBufferRange()
+    });
+  }
 
-    updateRange(fn) {
-        return () => {
-            this.editor.setTextInBufferRange(
-                this.state.range,
-                fn(this.editor.getTextInBufferRange(this.state.range))
-            );
+  updateRange(text) {
+    this.editor.setTextInBufferRange(this.state.range, text);
 
-            this.setState({
-                range: this.editor.getSelectedBufferRange(),
-            });
-        };
-    }
+    this.setState({
+      range: this.editor.getSelectedBufferRange()
+    });
+  }
 
-    initializeEvents(editor) {
-        if (path.basename(editor.getTitle(), '.md') === editor.getTitle())
-            return this.setState({ hidden: true });
+  initializeEvents(editor) {
+    if (path.basename(editor.getTitle(), ".md") === editor.getTitle())
+      return this.setState({ hidden: true });
 
-        this.subscriber && this.subscriber.unsubscribe();
+    this.subscriber && this.subscriber.unsubscribe();
 
-        const element = atom.views.getView(editor);
+    const element = atom.views.getView(editor);
 
-        const selection$ = new Subject();
+    const selection$ = new Subject();
 
-        editor.onDidChangeSelectionRange(selection$.next.bind(selection$));
+    editor.onDidChangeSelectionRange(selection$.next.bind(selection$));
 
-        const [menu$, click$] = Observable.fromEvent(element, 'mouseup')
-            .withLatestFrom(
-                selection$,
-                ({ clientX, clientY }, { newBufferRange }) => ({
-                    range: newBufferRange,
-                    left: clientX,
-                    top: clientY,
-                })
-            )
-            .partition(({ range }) => !range.end.isEqual(range.start));
+    const [menu$, click$] = Observable.fromEvent(element, "mouseup")
+      .withLatestFrom(
+        selection$,
+        ({ clientX, clientY }, { newBufferRange }) => ({
+          range: newBufferRange,
+          left: clientX,
+          top: clientY
+        })
+      )
+      .partition(({ range }) => !range.end.isEqual(range.start));
 
-        this.subscriber = Observable.fromEvent(element, 'mousewheel')
-            .merge(Observable.fromEvent(element, 'keydown'))
-            .merge(click$)
-            .filter(() => !this.state.hidden)
-            .subscribe(() => this.setState({ hidden: true }))
-            .add(
-                menu$
-                    .map(({ range, left, top }) => ({
-                        position: { left: left + 10, top: top + 10 },
-                        line: editor.getCursorBufferPosition().row,
-                        hidden: false,
-                        range,
-                    }))
-                    .subscribe(options => this.setState(options))
-            );
+    this.subscriber = Observable.fromEvent(element, "mousewheel")
+      .merge(Observable.fromEvent(element, "keydown"))
+      .merge(click$)
+      .filter(() => !this.state.hidden)
+      .subscribe(() => this.setState({ hidden: true }))
+      .add(
+        menu$
+          .map(({ range, left, top }) => ({
+            position: { left: left + 10, top: top + 10 },
+            line: editor.getCursorBufferPosition().row,
+            hidden: false,
+            range
+          }))
+          .subscribe(options => this.setState(options))
+      );
 
-        this.editor = editor;
-    }
+    this.editor = editor;
+  }
 
-    componentDidMount() {
-        atom.workspace.onDidChangeActiveTextEditor(
-            this.initializeEvents.bind(this)
-        );
+  componentDidMount() {
+    atom.workspace.onDidChangeActiveTextEditor(
+      this.initializeEvents.bind(this)
+    );
 
-        if (this.editor) this.initializeEvents(this.editor);
-    }
+    if (this.editor) this.initializeEvents(this.editor);
+  }
 
-    render() {
-        return (
-            <Container
-                hidden={this.state.hidden}
-                position={this.state.position}
-            >
-                <EditorButton onClick={this.updateLine(header(1))}>
-                    H1
-                </EditorButton>
-                <EditorButton onClick={this.updateLine(header(2))}>
-                    H2
-                </EditorButton>
-                <EditorButton onClick={this.updateLine(quote)}>"</EditorButton>
-                <EditorButton onClick={this.updateRange(bold)}>B</EditorButton>
-                <EditorButton onClick={this.updateRange(italic)}>
-                    I
-                </EditorButton>
-                <EditorButton onClick={this.updateRange(link)}>
-                    Link
-                </EditorButton>
-            </Container>
-        );
-    }
+  onChange(text, line) {
+    line ? this.updateLine(text) : this.updateRange(text);
+  }
+
+  render() {
+    const { position, range, hidden, line } = this.state;
+
+    if (!range || hidden) return null;
+
+    return (
+      <MarkdownMenu
+        x={position.left}
+        y={position.top}
+        onChange={this.onChange.bind(this)}
+        lineSelection={this.editor.lineTextForBufferRow(line)}
+        selection={this.editor.getTextInBufferRange(range)}
+      />
+    );
+  }
 }

--- a/lib/editor/bold.js
+++ b/lib/editor/bold.js
@@ -1,0 +1,5 @@
+'use babel';
+
+export default function bold(str) {
+    return str.replace(/__.*__/, '') === str ? `__${str}__` : str.replace(/(__)(.*)(__)/, '$2');
+}

--- a/lib/editor/header.js
+++ b/lib/editor/header.js
@@ -1,0 +1,13 @@
+'use babel';
+
+import { curry, range } from 'ramda';
+
+const header = curry(function header(depth, str) {
+    return str.charAt(0) !== '#'
+        ? `${range(0, depth)
+              .map(() => '#')
+              .join('')} ${str}`
+        : str.replace(/[#]+ /, '').trim();
+});
+
+export default header;

--- a/lib/editor/italic.js
+++ b/lib/editor/italic.js
@@ -1,0 +1,7 @@
+'use babel';
+
+export default function italic(str) {
+    return str.replace(/_.*_/, '') === str
+        ? `_${str}_`
+        : str.replace(/(_)(.*)(_)/, '$2');
+}

--- a/lib/editor/link.js
+++ b/lib/editor/link.js
@@ -1,0 +1,7 @@
+'use babel';
+
+export default function link(str) {
+    return str.replace(/[.*](.*)/, '') === str
+        ? `[${str}]()`
+        : str.replace(/\[(.*)\]\(.*\)/, '$1');
+}

--- a/lib/editor/link.js
+++ b/lib/editor/link.js
@@ -1,7 +1,7 @@
 'use babel';
 
 export default function link(str) {
-    return str.replace(/[.*](.*)/, '') === str
+    return str.replace(/\[.*\]\(.*\)/, '') === str
         ? `[${str}]()`
         : str.replace(/\[(.*)\]\(.*\)/, '$1');
 }

--- a/lib/editor/quote.js
+++ b/lib/editor/quote.js
@@ -1,0 +1,5 @@
+'use babel';
+
+export default function quote(str) {
+    return str.charAt(0) !== '>' ? `> ${str}` : str.substr(1).trim();
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "medium-sdk": "0.0.3",
     "moment": "^2.13.0",
-    "prop-types": "^15.6.0",
     "ramda": "^0.25.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
@@ -32,8 +31,6 @@
     "underscore.string": "^3.3.4"
   },
   "devDependencies": {
-    "enzyme": "^3.3.0",
-    "prettier": "^1.10.2",
-    "sinon": "^4.2.2"
+    "prettier": "^1.10.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ramda": "^0.25.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
+    "react-markdown-menu": "^1.1.1",
     "rxjs": "^5.5.6",
     "styled-components": "^3.1.4",
     "underscore.string": "^3.3.4"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ramda": "^0.25.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-markdown-menu": "^1.1.1",
+    "react-markdown-menu": "^1.2.1",
     "rxjs": "^5.5.6",
     "styled-components": "^3.1.4",
     "underscore.string": "^3.3.4"

--- a/spec/bold-spec.js
+++ b/spec/bold-spec.js
@@ -1,0 +1,35 @@
+'use babel';
+
+import bold from '../lib/editor/bold';
+
+describe('.bold', () => {
+    it('should be a function with arity 1', () => {
+        // Assert
+        expect(typeof bold).toBe('function');
+        expect(bold.length).toEqual(1);
+    });
+
+    it('it should return a markdown bolded string', () => {
+        // Arrange
+        const str = 'sandwich';
+        const expectedStr = `__${str}__`;
+
+        // Act
+        const result = bold(str);
+
+        // Assert
+        expect(result).toEqual(expectedStr);
+    });
+
+    it('should unbold if the text is already bold', () => {
+        // Arrange
+        const expectedStr = 'sandwich';
+        const str = `__${expectedStr}__`;
+
+        // Act
+        const result = bold(str);
+
+        // Assert
+        expect(result).toEqual(expectedStr);
+    });
+});

--- a/spec/header-spec.js
+++ b/spec/header-spec.js
@@ -1,0 +1,47 @@
+'use babel';
+
+import header from '../lib/editor/header';
+
+describe('.header', () => {
+    it('should be a function with arity 1', () => {
+        // Assert
+        expect(typeof header).toBe('function');
+        expect(header.length).toEqual(2);
+    });
+
+    it('it should return a markdown header string', () => {
+        // Arrange
+        const str = 'this should be a line sandwich';
+        const expectedStr = `# ${str}`;
+
+        // Act
+        const result = header(1, str);
+
+        // Assert
+        expect(result).toEqual(expectedStr);
+    });
+
+    it('it should return a markdown header (2) string', () => {
+        // Arrange
+        const str = 'this should be a line sandwich';
+        const expectedStr = `## ${str}`;
+
+        // Act
+        const result = header(2, str);
+
+        // Assert
+        expect(result).toEqual(expectedStr);
+    });
+
+    it('should unheader if the line is already a header', () => {
+        // Arrange
+        const expectedStr = 'this should be a line sandwich';
+        const str = `## ${expectedStr}`;
+
+        // Act
+        const result = header(1, str);
+
+        // Assert
+        expect(result).toEqual(expectedStr);
+    });
+});

--- a/spec/italic-spec.js
+++ b/spec/italic-spec.js
@@ -1,0 +1,35 @@
+'use babel';
+
+import italic from '../lib/editor/italic';
+
+describe('.italic', () => {
+    it('should be a function with arity 1', () => {
+        // Assert
+        expect(typeof italic).toBe('function');
+        expect(italic.length).toEqual(1);
+    });
+
+    it('it should return a markdown italic string', () => {
+        // Arrange
+        const str = 'sandwich';
+        const expectedStr = `_${str}_`;
+
+        // Act
+        const result = italic(str);
+
+        // Assert
+        expect(result).toEqual(expectedStr);
+    });
+
+    it('should unitalic if the text is already italic', () => {
+        // Arrange
+        const expectedStr = 'sandwich';
+        const str = `_${expectedStr}_`;
+
+        // Act
+        const result = italic(str);
+
+        // Assert
+        expect(result).toEqual(expectedStr);
+    });
+});

--- a/spec/link-spec.js
+++ b/spec/link-spec.js
@@ -1,0 +1,47 @@
+'use babel';
+
+import link from '../lib/editor/link';
+
+describe('.link', () => {
+    it('should be a function with arity 1', () => {
+        // Assert
+        expect(typeof link).toBe('function');
+        expect(link.length).toEqual(1);
+    });
+
+    it('it should return a markdown link string', () => {
+        // Arrange
+        const str = 'sandwich';
+        const expectedStr = `[${str}]()`;
+
+        // Act
+        const result = link(str);
+
+        // Assert
+        expect(result).toEqual(expectedStr);
+    });
+
+    it('should unlink if the text is already link', () => {
+        // Arrange
+        const expectedStr = 'sandwich';
+        const str = `[${expectedStr}](http://google.ca)`;
+
+        // Act
+        const result = link(str);
+
+        // Assert
+        expect(result).toEqual(expectedStr);
+    });
+
+    it('should unlink if the text is already link, but empty', () => {
+        // Arrange
+        const expectedStr = 'sandwich';
+        const str = `[${expectedStr}]()`;
+
+        // Act
+        const result = link(str);
+
+        // Assert
+        expect(result).toEqual(expectedStr);
+    });
+});

--- a/spec/quote-spec.js
+++ b/spec/quote-spec.js
@@ -1,0 +1,35 @@
+'use babel';
+
+import quote from '../lib/editor/quote';
+
+describe('.quote', () => {
+    it('should be a function with arity 1', () => {
+        // Assert
+        expect(typeof quote).toBe('function');
+        expect(quote.length).toEqual(1);
+    });
+
+    it('it should return a markdown quote string', () => {
+        // Arrange
+        const str = 'this should be a line sandwich';
+        const expectedStr = `> ${str}`;
+
+        // Act
+        const result = quote(str);
+
+        // Assert
+        expect(result).toEqual(expectedStr);
+    });
+
+    it('should unquote if the line is already a quote', () => {
+        // Arrange
+        const expectedStr = 'this should be a line sandwich';
+        const str = `> ${expectedStr}`;
+
+        // Act
+        const result = quote(str);
+
+        // Assert
+        expect(result).toEqual(expectedStr);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,9 +152,9 @@ react-dom@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-markdown-menu@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/react-markdown-menu/-/react-markdown-menu-1.1.1.tgz#21c252f5fb8ef55bf7fe27c257d0eee3b35e11b5"
+react-markdown-menu@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-markdown-menu/-/react-markdown-menu-1.2.1.tgz#bef1ac49ca79d0109edc4a31e20ece36f1568dee"
   dependencies:
     prop-types "^15.6.0"
     ramda "^0.25.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,6 +152,15 @@ react-dom@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-markdown-menu@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/react-markdown-menu/-/react-markdown-menu-1.1.1.tgz#21c252f5fb8ef55bf7fe27c257d0eee3b35e11b5"
+  dependencies:
+    prop-types "^15.6.0"
+    ramda "^0.25.0"
+    rxjs "^5.5.6"
+    styled-components "^3.1.6"
+
 react@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
@@ -178,6 +187,20 @@ sprintf-js@^1.0.3:
 styled-components@^3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.1.4.tgz#1bdc1409c9bacafee3510c573d23b73039b0d875"
+  dependencies:
+    buffer "^5.0.3"
+    css-to-react-native "^2.0.3"
+    fbjs "^0.8.9"
+    hoist-non-react-statics "^1.2.0"
+    is-plain-object "^2.0.1"
+    prop-types "^15.5.4"
+    stylis "^3.4.0"
+    stylis-rule-sheet "^0.0.7"
+    supports-color "^3.2.3"
+
+styled-components@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.1.6.tgz#9c443146fa82c6659a9f64dd493bf2202480342e"
   dependencies:
     buffer "^5.0.3"
     css-to-react-native "^2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,6 @@
 # yarn lockfile v1
 
 
-"@types/node@*":
-  version "9.4.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.0.tgz#b85a0bcf1e1cc84eb4901b7e96966aedc6f078d1"
-
 asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
@@ -14,10 +10,6 @@ base64-js@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
 
-boolbase@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
-
 buffer@^5.0.3:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.0.8.tgz#84daa52e7cf2fa8ce4195bc5cf0f7809e0930b24"
@@ -25,41 +17,13 @@ buffer@^5.0.3:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
 
-cheerio@^1.0.0-rc.2:
-  version "1.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
-  dependencies:
-    css-select "~1.2.0"
-    dom-serializer "~0.1.0"
-    entities "~1.1.1"
-    htmlparser2 "^3.9.1"
-    lodash "^4.15.0"
-    parse5 "^3.0.1"
-
-colors@0.5.x:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
-
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-util-is@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-
 css-color-keywords@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
-
-css-select@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
-  dependencies:
-    boolbase "~1.0.0"
-    css-what "2.1"
-    domutils "1.5.1"
-    nth-check "~1.0.1"
 
 css-to-react-native@^2.0.3:
   version "2.0.4"
@@ -69,108 +33,11 @@ css-to-react-native@^2.0.3:
     fbjs "^0.8.5"
     postcss-value-parser "^3.3.0"
 
-css-what@2.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
-
-define-properties@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
-  dependencies:
-    foreach "^2.0.5"
-    object-keys "^1.0.8"
-
-diff@^3.1.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
-
-discontinuous-range@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
-
-dom-serializer@0, dom-serializer@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
-  dependencies:
-    domelementtype "~1.1.1"
-    entities "~1.1.1"
-
-domelementtype@1, domelementtype@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
-
-domelementtype@~1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
-
-domhandler@^2.3.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.1.tgz#892e47000a99be55bbf3774ffea0561d8879c259"
-  dependencies:
-    domelementtype "1"
-
-domutils@1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
-
-domutils@^1.5.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.6.2.tgz#1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff"
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
-
 encoding@^0.1.11:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
   dependencies:
     iconv-lite "~0.4.13"
-
-entities@^1.1.1, entities@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
-
-enzyme@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.3.0.tgz#0971abd167f2d4bf3f5bd508229e1c4b6dc50479"
-  dependencies:
-    cheerio "^1.0.0-rc.2"
-    function.prototype.name "^1.0.3"
-    has "^1.0.1"
-    is-boolean-object "^1.0.0"
-    is-callable "^1.1.3"
-    is-number-object "^1.0.3"
-    is-string "^1.0.4"
-    is-subset "^0.1.1"
-    lodash "^4.17.4"
-    object-inspect "^1.5.0"
-    object-is "^1.0.1"
-    object.assign "^4.1.0"
-    object.entries "^1.0.4"
-    object.values "^1.0.4"
-    raf "^3.4.0"
-    rst-selector-parser "^2.2.3"
-
-es-abstract@^1.6.1:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.10.0.tgz#1ecb36c197842a00d8ee4c2dfd8646bb97d60864"
-  dependencies:
-    es-to-primitive "^1.1.1"
-    function-bind "^1.1.1"
-    has "^1.0.1"
-    is-callable "^1.1.3"
-    is-regex "^1.0.4"
-
-es-to-primitive@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
-  dependencies:
-    is-callable "^1.1.1"
-    is-date-object "^1.0.1"
-    is-symbol "^1.0.1"
 
 fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.16"
@@ -184,60 +51,13 @@ fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-foreach@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
-
-formatio@1.2.0, formatio@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
-  dependencies:
-    samsam "1.x"
-
-function-bind@^1.0.2, function-bind@^1.1.0, function-bind@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
-
-function.prototype.name@^1.0.3:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.0.tgz#8bd763cc0af860a859cc5d49384d74b932cd2327"
-  dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.1.1"
-    is-callable "^1.1.3"
-
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
-has-flag@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
-
-has-symbols@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
-
-has@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
-  dependencies:
-    function-bind "^1.0.2"
-
 hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
-
-htmlparser2@^3.9.1:
-  version "3.9.2"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
-  dependencies:
-    domelementtype "^1.3.0"
-    domhandler "^2.3.0"
-    domutils "^1.5.1"
-    entities "^1.1.1"
-    inherits "^2.0.1"
-    readable-stream "^2.0.2"
 
 iconv-lite@~0.4.13:
   version "0.4.19"
@@ -247,61 +67,15 @@ ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
-inherits@^2.0.1, inherits@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
-
-is-boolean-object@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
-
-is-callable@^1.1.1, is-callable@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
-
-is-date-object@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
-
-is-number-object@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.3.tgz#f265ab89a9f445034ef6aff15a8f00b00f551799"
-
 is-plain-object@^2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   dependencies:
     isobject "^3.0.1"
 
-is-regex@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
-  dependencies:
-    has "^1.0.1"
-
 is-stream@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-
-is-string@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.4.tgz#cc3a9b69857d621e963725a24caeec873b826e64"
-
-is-subset@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
-
-is-symbol@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
-
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-
-isarray@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
 isobject@^3.0.1:
   version "3.0.1"
@@ -318,30 +92,6 @@ js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-just-extend@^1.1.26:
-  version "1.1.27"
-  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
-
-lodash.flattendeep@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
-
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-
-lodash@^4.15.0, lodash@^4.17.4:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
-lolex@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
-
-lolex@^2.2.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.3.2.tgz#85f9450425103bf9e7a60668ea25dc43274ca807"
-
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
@@ -356,24 +106,6 @@ moment@^2.13.0:
   version "2.20.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.20.1.tgz#d6eb1a46cbcc14a2b2f9434112c1ff8907f313fd"
 
-nearley@^2.7.10:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.11.0.tgz#5e626c79a6cd2f6ab9e7e5d5805e7668967757ae"
-  dependencies:
-    nomnom "~1.6.2"
-    railroad-diagrams "^1.0.0"
-    randexp "^0.4.2"
-
-nise@^1.2.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-1.2.2.tgz#9aa5edb500da38035884106e3c571341bc68b2c1"
-  dependencies:
-    formatio "^1.2.0"
-    just-extend "^1.1.26"
-    lolex "^1.6.0"
-    path-to-regexp "^1.7.0"
-    text-encoding "^0.6.4"
-
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -381,77 +113,9 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-nomnom@~1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.6.2.tgz#84a66a260174408fc5b77a18f888eccc44fb6971"
-  dependencies:
-    colors "0.5.x"
-    underscore "~1.4.4"
-
-nth-check@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
-  dependencies:
-    boolbase "~1.0.0"
-
 object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-
-object-inspect@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.5.0.tgz#9d876c11e40f485c79215670281b767488f9bfe3"
-
-object-is@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
-
-object-keys@^1.0.11, object-keys@^1.0.8:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
-
-object.assign@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
-  dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.1.1"
-    has-symbols "^1.0.0"
-    object-keys "^1.0.11"
-
-object.entries@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.0.4.tgz#1bf9a4dd2288f5b33f3a993d257661f05d161a5f"
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.6.1"
-    function-bind "^1.1.0"
-    has "^1.0.1"
-
-object.values@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.0.4.tgz#e524da09b4f66ff05df457546ec72ac99f13069a"
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.6.1"
-    function-bind "^1.1.0"
-    has "^1.0.1"
-
-parse5@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
-  dependencies:
-    "@types/node" "*"
-
-path-to-regexp@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
-  dependencies:
-    isarray "0.0.1"
-
-performance-now@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
 postcss-value-parser@^3.3.0:
   version "3.3.0"
@@ -460,10 +124,6 @@ postcss-value-parser@^3.3.0:
 prettier@^1.10.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
-
-process-nextick-args@~1.0.6:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
 promise@^7.1.1:
   version "7.3.1"
@@ -479,26 +139,9 @@ prop-types@^15.5.4, prop-types@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-raf@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
-  dependencies:
-    performance-now "^2.1.0"
-
-railroad-diagrams@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
-
 ramda@^0.25.0:
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
-
-randexp@^0.4.2:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
-  dependencies:
-    discontinuous-range "1.0.0"
-    ret "~0.1.10"
 
 react-dom@^16.2.0:
   version "16.2.0"
@@ -518,68 +161,19 @@ react@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-readable-stream@^2.0.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.0.3"
-    util-deprecate "~1.0.1"
-
-ret@~0.1.10:
-  version "0.1.15"
-  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
-
-rst-selector-parser@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz#81b230ea2fcc6066c89e3472de794285d9b03d91"
-  dependencies:
-    lodash.flattendeep "^4.4.0"
-    nearley "^2.7.10"
-
 rxjs@^5.5.6:
   version "5.5.6"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.6.tgz#e31fb96d6fd2ff1fd84bcea8ae9c02d007179c02"
   dependencies:
     symbol-observable "1.0.1"
 
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
-
-samsam@1.x:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
-
 setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
-sinon@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.2.2.tgz#e039ab27bdb426fc61363c380726e996a2e2c620"
-  dependencies:
-    diff "^3.1.0"
-    formatio "1.2.0"
-    lodash.get "^4.4.2"
-    lolex "^2.2.0"
-    nise "^1.2.0"
-    supports-color "^5.1.0"
-    type-detect "^4.0.5"
-
 sprintf-js@^1.0.3:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.1.tgz#36be78320afe5801f6cea3ee78b6e5aab940ea0c"
-
-string_decoder@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
-  dependencies:
-    safe-buffer "~5.1.0"
 
 styled-components@^3.1.4:
   version "3.1.4"
@@ -609,23 +203,9 @@ supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.1.0.tgz#058a021d1b619f7ddf3980d712ea3590ce7de3d5"
-  dependencies:
-    has-flag "^2.0.0"
-
 symbol-observable@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
-
-text-encoding@^0.6.4:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
-
-type-detect@^4.0.5:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.7.tgz#862bd2cf6058ad92799ff5a5b8cf7b6cec726198"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"
@@ -638,11 +218,7 @@ underscore.string@^3.3.4:
     sprintf-js "^1.0.3"
     util-deprecate "^1.0.2"
 
-underscore@~1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
-
-util-deprecate@^1.0.2, util-deprecate@~1.0.1:
+util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 


### PR DESCRIPTION
When editing a `md` document in atom with the __Medium Editor__ enabled there is a context WYSIWYG editor that will appear when a selection is made.

## ⚠️ This issue depends on #17 

![kapture 2018-02-07 at 11 21 51](https://user-images.githubusercontent.com/6516758/35927671-3e0608f6-0bf9-11e8-96ea-852534844966.gif)
